### PR TITLE
示例代码无法编译通过，原来是少了个空格

### DIFF
--- a/docs/getting-started/start.md
+++ b/docs/getting-started/start.md
@@ -53,7 +53,7 @@ kratos proto server api/helloworld/helloworld.proto -t internal/service
 ## 项目编译和运行
 ```bash
 # 生成所有proto源码、wire等等
-go generate ./...
+go generate ./.. .
 
 # 编译成可执行文件
 go build -o ./bin/ ./...


### PR DESCRIPTION
56行 需要加一个空格, 原：go generate ./... 修改成 go generate ./.. .
好奇的是，第62行不存在这个问题[手动狗头]