### PR TITLE
fix:kratos 组件版本不一致导致生成模版出错

### DIFF
--- a/docs/getting-started/start.md
+++ b/docs/getting-started/start.md
@@ -34,6 +34,8 @@ go env -w GO111MODULE=on
 ```bash
 # 安装 kratos 命令工具
 go get -u github.com/go-kratos/kratos/cmd/kratos/v2@latest
+# 可能不是最新的项目，可以执行
+kratos upgrade
 ```
 ## 创建项目
 ```bash


### PR DESCRIPTION
go generate ./... 
时模版不是最新模版，执行 kratos upgrade 保证获取的组件最新