### PR TITLE
fix: error struct assign

### DIFF
--- a/blog/2021-07-14-go-project-wire.md
+++ b/blog/2021-07-14-go-project-wire.md
@@ -200,7 +200,7 @@ type redis struct {
 }
 
 func NewRedis(addr string) *redis {
-    return &redis{db: NewRedisClient(addr)}
+    return &redis{r: NewRedisClient(addr)}
 }
 
 func (r *redis) GetById(id string) string {
@@ -214,7 +214,7 @@ type mysql struct {
 }
 
 func NewMySQL(addr string) *redis {
-    return &mysql{db: NewMySQLClient(addr)}
+    return &mysql{m: NewMySQLClient(addr)}
 }
 
 func (m *mysql) GetById(id string) string {


### PR DESCRIPTION
``` golang
type redis struct {
    r *RedisClient
}

// there is no key named db. changed to r
func NewRedis(addr string) *redis {
    return &redis{r: NewRedisClient(addr)}
}



// 再封装个mysql
type mysql struct {
    m *MySQLClient
}

// there is no key named db. changed to m 

func NewMySQL(addr string) *redis {
    return &mysql{m: NewMySQLClient(addr)}
}

```