### PR TITLE
Update usage.md

### DIFF
--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -16,7 +16,7 @@ keywords:
 ### 安装
 
 ```bash
-go get -u github.com/go-kratos/kratos/cmd/kratos/v2@latest
+go install github.com/go-kratos/kratos/cmd/kratos/v2@latest
 ```
 
 ### 工具使用


### PR DESCRIPTION
Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.