### PR TITLE
docs(auth): The whitelist reference scheme link is outdated

### DIFF
--- a/docs/component/middleware/02-auth.md
+++ b/docs/component/middleware/02-auth.md
@@ -146,7 +146,7 @@ func FromContext(ctx context.Context) (token jwt.Claims, ok bool)
 
 ### 白名单参考方案
 
-结合 `selector` 中间件使用实现白名单机制。可参考：https://github.com/go-kratos/beer-shop/blob/a29eae57a9baeae9969e9a7d418ff677cf494a21/app/shop/interface/internal/server/http.go#L41
+结合 `selector` 中间件使用实现白名单机制。可参考[此处](https://github.com/go-kratos/beer-shop/blob/b12402ebc618c4563e69757e65a6db4dd767a869/app/shop/interface/internal/server/http.go#L26)。
 
 ### 签发 `JWT Token`
 


### PR DESCRIPTION
修改前，白名单参考链接中的代码如下。
![修改前](https://user-images.githubusercontent.com/62499904/180186104-571f3a0d-79bd-4db9-be5c-f57b602afb81.png)

修改后，白名单参考链接中的代码如下。
![修改后](https://user-images.githubusercontent.com/62499904/180186308-dca84203-e2a5-4885-a7a2-0faae83192ee.png)

在全新的 Kratos 中，添加白名单的参数为 `func(ctx context.Context, operation string) bool`，不兼容旧版本。

另外，还将参考链接使用了 `[]()` 的 `markdown` 语法，看起来更简洁，修改后如下。 : -)
![image](https://user-images.githubusercontent.com/62499904/180187204-bfe1e89e-5fca-456e-b7ca-e93f9df886d7.png)

