### PR TITLE
fix: add latest tag to installation uri

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/getting-started/01-start.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/getting-started/01-start.md
@@ -26,7 +26,7 @@ If you faced with network problem (especially you are in China Mainland), please
 #### 1. go install installation
 
 ```bash
-go install github.com/go-kratos/kratos/cmd/kratos/v2
+go install github.com/go-kratos/kratos/cmd/kratos/v2@latest
 ```
 
 #### 2. Source code compilation and installation


### PR DESCRIPTION
Because go forces it to use `latest` tag. A very short waste of time for developers who follow a path from kratos docs.