### PR TITLE
feat: update gh actions yml

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,18 +22,9 @@ jobs:
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
-      # - name: Deploy to GitHub Pages
-      #   uses: peaceiris/actions-gh-pages@v3.7.3
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     # Build output to publish to the `gh-pages` branch:
-      #     publish_dir: ./build
-
-      #   JamesIves/Deploy to github pages
-      # Docs: https://github.com/JamesIves/github-pages-deploy-action#getting-started-airplane
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: peaceiris/actions-gh-pages@v3.9.0
         with:
-            folder: ./build
-            # token: This option defaults to the repository scoped GitHub Token.
-            # github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./build

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,7 +9,7 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -23,7 +23,7 @@ jobs:
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v3.7.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,9 +22,18 @@ jobs:
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
+      # - name: Deploy to GitHub Pages
+      #   uses: peaceiris/actions-gh-pages@v3.7.3
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     # Build output to publish to the `gh-pages` branch:
+      #     publish_dir: ./build
+
+      #   JamesIves/Deploy to github pages
+      # Docs: https://github.com/JamesIves/github-pages-deploy-action#getting-started-airplane
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3.7.3
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./build
+            folder: ./build
+            # token: This option defaults to the repository scoped GitHub Token.
+            # github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitee_sync.yml
+++ b/.github/workflows/gitee_sync.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Mirror Github to Gitee
         uses: Yikun/hub-mirror-action@v1.2
         with:


### PR DESCRIPTION
[The latest Actions](https://github.com/go-kratos/go-kratos.dev/actions/runs/3273414630) running has the [problem](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).  
So update the checkout version and the [actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) version. But the **actions-gh-pages** latest release no solve this problem. The reference [issue](https://github.com/peaceiris/actions-gh-pages/issues/677) is open.
I have replaced the old version with [JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action).
