### PR TITLE
docs(guide): 修复了04-ent文档内的命令错误

### DIFF
--- a/docs/guide/04-ent.md
+++ b/docs/guide/04-ent.md
@@ -26,13 +26,13 @@ keywords:
 ### 安装工具
 
 ```bash
-go install entgo.io/ent/cmd/ent
+go install entgo.io/ent/cmd/ent@latest
 ```
 
 ### 创建实体 Schema
 
 ```bash
-ent init User
+ent new User
 ```
 
 将会在 *project/ent/schema/* 目录下为用户生成模式:
@@ -85,6 +85,7 @@ func (User) Fields() []ent.Field {
 
 ```
 go generate ./ent
+# ent generate ./ent/schema
 ```
 
 ### 创建数据库连接客户端

--- a/i18n/en/docusaurus-plugin-content-docs/current/guide/04-ent.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guide/04-ent.md
@@ -10,13 +10,13 @@ Any ORM or library is supported in Kratos project for data accessing. Please ref
 ### Install Ent
 
 ```bash
-go install entgo.io/ent/cmd/ent
+go install entgo.io/ent/cmd/ent@latest
 ```
 
 ### Create Schema
 
 ```bash
-ent init User
+ent new User
 ```
 
 This command will generate schema in `project/ent/schema/` directory.
@@ -68,6 +68,7 @@ func (User) Fields() []ent.Field {
 Run `go generate`:
 ```
 go generate ./ent
+# ent generate ./ent/schema
 ```
 
 ### Create DB Connection Client


### PR DESCRIPTION
中英文文档已同步修改

1. go install 需要添加版本号
2. ent 创建的新对象的方式已经由ent init XX 改为 ent new XX
3. ent 生成代码的命令也新增了ent generate ./ent/schema 的方式

