### PR TITLE
fix: kratos do not support placeholder format "$XX"

### DIFF
--- a/docs/component/02-config.md
+++ b/docs/component/02-config.md
@@ -206,7 +206,7 @@ http:
     name: "${service.name}"
     # 使用环境变量 PORT 替换，若不存在，使用默认值 8080
     port: "${PORT:8080}"
-    # 使用环境变量 TIMEOUT 替换，无默认值
+    # 不支持该格式，会被当作普通字符串处理
     timeout: "$TIMEOUT"
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/component/02-config.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/component/02-config.md
@@ -204,7 +204,7 @@ http:
     name: "${service.name}"
     # Replace with the environment variable PORT, if it does not exist, use the default value 8080
     port: "${PORT:8080}"
-    # Replace with the environment variable TIMEOUT, no default value
+    # This format is not supported and will be treated as a regular string
     timeout: "$TIMEOUT"
 ```
 


### PR DESCRIPTION
Kratos don't support placeholder format "$XX" as default [details](https://github.com/go-kratos/kratos/issues/3198).