### PR TITLE
fix: installation dependency

### DIFF
--- a/docs/getting-started/01-start.md
+++ b/docs/getting-started/01-start.md
@@ -59,6 +59,8 @@ go mod download
 ### 代码生成与运行
 #### 生成
 ```bash
+# 安装依赖
+go get github.com/google/wire/cmd/wire@latest
 # 生成所有proto源码、wire等等
 go generate ./...
 ```

--- a/i18n/en/docusaurus-plugin-content-docs/current/getting-started/01-start.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/getting-started/01-start.md
@@ -49,6 +49,8 @@ go mod download
 ```
 ## Compilation and Running
 ```bash
+# installation dependency
+go get github.com/google/wire/cmd/wire@latest
 # generate all codes of proto and wire etc.
 go generate ./...
 


### PR DESCRIPTION
```bash
❯ go generate ./...
/Users/kalifun/go/pkg/mod/github.com/google/wire@v0.5.0/cmd/wire/main.go:34:2: missing go.sum entry for module providing package github.com/google/subcommands (imported by github.com/google/wire/cmd/wire); to add:
	go get github.com/google/wire/cmd/wire@v0.5.0
```

It is possible that the user has not installed the relevant dependency, so it is recommended that the user perform the installation dependency operation first.