### PR TITLE
doc: middleware/tracing updated the usage with otlptracehttp instead of deprecated jaeger

### DIFF
--- a/docs/component/middleware/08-tracing.md
+++ b/docs/component/middleware/08-tracing.md
@@ -56,16 +56,19 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/jaeger"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 )
 
 // 设置全局trace
-func initTracer(url string) error {
-	// 创建 Jaeger exporter
-	exp, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(url)))
+func initTracer(endpoint string) error {
+	// 创建 exporter
+	exporter, err := otlptracehttp.New(context.Background(),
+		otlptracehttp.WithEndpoint(endpoint),
+		otlptracehttp.WithInsecure(),
+	)
 	if err != nil {
 		return err
 	}
@@ -73,11 +76,11 @@ func initTracer(url string) error {
 		// 将基于父span的采样率设置为100%
 		tracesdk.WithSampler(tracesdk.ParentBased(tracesdk.TraceIDRatioBased(1.0))),
 		// 始终确保在生产中批量处理
-		tracesdk.WithBatcher(exp),
+		tracesdk.WithBatcher(exporter),
 		// 在资源中记录有关此应用程序的信息
 		tracesdk.WithResource(resource.NewSchemaless(
 			semconv.ServiceNameKey.String("kratos-trace"),
-			attribute.String("exporter", "jaeger"),
+			attribute.String("exporter", "otlp"),
 			attribute.Float64("float", 312.23),
 		)),
 	)
@@ -87,7 +90,7 @@ func initTracer(url string) error {
 
 // NewGRPCServer new a gRPC server.
 func NewGRPCServer(c *conf.Server, executor *service.ExecutorService) *grpc.Server {
-	err := initTracer("http://localhost:14268/api/traces")
+	err := initTracer("localhost:4318")
 	if err != nil {
 		panic(err)
 	}
@@ -114,7 +117,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/jaeger"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
@@ -122,21 +125,24 @@ import (
 )
 
 // 设置全局trace
-func initTracer(url string) error {
-	// 创建 Jaeger exporter
-	exp, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(url)))
+func initTracer(endpoint string) error {
+	// 创建 exporter
+	exporter, err := otlptracehttp.New(context.Background(),
+		otlptracehttp.WithEndpoint(endpoint),
+		otlptracehttp.WithInsecure(),
+	)
 	if err != nil {
 		return err
 	}
 	tp := tracesdk.NewTracerProvider(
 		// 将基于父span的采样率设置为100%
 		tracesdk.WithSampler(tracesdk.ParentBased(tracesdk.TraceIDRatioBased(1.0))),
-		// 始终确保再生成中批量处理
-		tracesdk.WithBatcher(exp),
+		// 始终确保在生产中批量处理
+		tracesdk.WithBatcher(exporter),
 		// 在资源中记录有关此应用程序的信息
 		tracesdk.WithResource(resource.NewSchemaless(
 			semconv.ServiceNameKey.String("kratos-trace"),
-			attribute.String("exporter", "jaeger"),
+			attribute.String("exporter", "otlp"),
 			attribute.Float64("float", 312.23),
 		)),
 	)


### PR DESCRIPTION
`go.opentelemetry.io/otel/exporters/jaeger`

Deprecated: This module is no longer supported. OpenTelemetry dropped support for Jaeger exporter in July 2023. Jaeger officially accepts and recommends using OTLP. 