### PR TITLE
fix upload example link and typo

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/intro/02-design.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/intro/02-design.md
@@ -111,7 +111,7 @@ message HelloReply {
   string message = 1;
 }
 ```
-It should be noted that although the API defined by Protobuf is more reliable, the flexibility of the field structure is weaker than that of JSON. Therefore, if you have a file upload interface, or some JSON structure that cannot correspond to proto. You can define these interfaces outside of our API-System, implement as normal `http.Handler` and mount it on the route, or just use `struct` to define your fields. Here is an example of [upload](https://github.com/go-kratos/kratos/blob/main/examples/http/upload/main.go).
+It should be noted that although the API defined by Protobuf is more reliable, the flexibility of the field structure is weaker than that of JSON. Therefore, if you have a file upload interface, or some JSON structure that cannot correspond to proto. You can define these interfaces outside of our API-System, implement as normal `http.Handler` and mount it on the route, or just use `struct` to define your fields. Here is an example of [upload](https://github.com/go-kratos/examples/blob/main/http/upload/main.go).
 
 ## Metadata
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/intro/03-faq.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/intro/03-faq.md
@@ -18,7 +18,7 @@ This issue is mainly caused by the improperly installation of protoc. The docume
 
 
 ### 2. There are errors from IDE show `import "google/api/annotations.proto";` with red wavy line 
-You can append `thrid_party` directory to custom protobuf`s include paths. Please follow these doc:
+You can append `third_party` directory to custom protobuf`s include paths. Please follow these doc:
 
 * [GoLand](https://github.com/ksprojects/protobuf-jetbrains-plugin#configuration) 
 * [VSCode](https://github.com/zxh0/vscode-proto3#extension-settings)


### PR DESCRIPTION
Link to 'upload example' was out of date in the `02-design.md` docs, also a minor typo
https://github.com/go-kratos/examples/blob/main/http/upload/main.go